### PR TITLE
Stubout an example distribution class

### DIFF
--- a/pyinform/pyinform.pyx
+++ b/pyinform/pyinform.pyx
@@ -7,8 +7,6 @@ cdef extern from "stdint.h":
 
 cdef extern from "inform/time_series.h":
     double inform_active_info(const uint64_t* series, size_t n, uint64_t base, uint64_t k)
-
-cdef extern from "inform/time_series.h":
     double inform_active_info_ensemble(const uint64_t* series, size_t n, size_t m, uint64_t base, uint64_t k)
 
 def activeinfo1d(arr, uint64_t k, uint64_t b):

--- a/pyinform/pyinform.pyx
+++ b/pyinform/pyinform.pyx
@@ -5,6 +5,32 @@ import numpy
 cdef extern from "stdint.h":
     ctypedef unsigned long uint64_t
 
+cdef extern from "inform/dist.h":
+    ctypedef struct inform_dist:
+        pass
+
+    inform_dist* inform_dist_alloc(size_t n)
+    void inform_dist_free(inform_dist* dist)
+
+    size_t inform_dist_size(const inform_dist* dist);
+
+cdef class Dist:
+    cdef inform_dist* _c_dist
+    def __cinit__(self, n):
+        if n <= 0:
+            raise ValueError("distributions require positive, nonzero support")
+
+        self._c_dist = inform_dist_alloc(n)
+        if self._c_dist is NULL:
+            raise MemoryError()
+
+    def __dealloc__(self):
+        if self._c_dist is not NULL:
+            inform_dist_free(self._c_dist)
+
+    def __len__(self):
+        return inform_dist_size(self._c_dist)
+
 cdef extern from "inform/time_series.h":
     double inform_active_info(const uint64_t* series, size_t n, uint64_t base, uint64_t k)
     double inform_active_info_ensemble(const uint64_t* series, size_t n, size_t m, uint64_t base, uint64_t k)

--- a/test/test_dist.py
+++ b/test/test_dist.py
@@ -1,0 +1,19 @@
+import unittest
+from pyinform import Dist
+from math import isnan
+
+class TestDist(unittest.TestCase):
+    def testCannotAllocZero(self):
+        with self.assertRaises(ValueError):
+            Dist(-1)
+
+        with self.assertRaises(ValueError):
+            Dist(0)
+
+    def testAlloc(self):
+        d = Dist(5)
+        self.assertEqual(5, d.__len__())
+        self.assertEqual(5, len(d))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The objective of this class it to encapsulate the memory (de)allocation that is often necessary when dealing with C structures. Here we wrap up the `inform_dist` structure in a class called `Dist`. The allocation of the `inform_dist` object is mad within the `Dist.__cinit__` constructor, and deallocation is made via the `Dist.__dealloc__` method. Both of these methods are called implicitly, so no care is required on the end user's part.

As a quick testing method we create the `Dist.__len__` method which lets use call the `len` function on distributions, returning the size of the distribution's support.

Tests are included.

A couple of things that might be interesting in the coming commits:
* Wrap `inform_dist_get` as `Dist.__getitem__` which overloads the indexing operator to return the number of observations made, e.g. `dist[2]` would return the number of observations of event number 2.
* Wrap `inform_dist_set` as `Dist.__setitem__` which allows such conveniences as `dist[2] = 5`.
