### PR TITLE
Update to the newest Inform version

### DIFF
--- a/pyinform/pyinform.pyx
+++ b/pyinform/pyinform.pyx
@@ -137,6 +137,9 @@ cdef class Dist:
 cdef extern from "inform/active_info.h":
     double inform_active_info(const uint64_t* series, size_t n, size_t m, uint64_t base, uint64_t k)
 
+cdef extern from "inform/entropy_rate.h":
+    double inform_entropy_rate(const uint64_t* series, size_t n, size_t m, uint64_t base, uint64_t k)
+
 cdef extern from "inform/transfer_entropy.h":
     double inform_transfer_entropy(const uint64_t* seriesy, const uint64_t* seriesx, size_t n, size_t m, uint64_t base, uint64_t k)
 
@@ -260,7 +263,7 @@ def entropyrate1d(arr, uint64_t k, uint64_t b):
         b = max(2,max(arr)+1)
 
     cdef uint64_t [:] ys = arr
-    er = inform_entropy_rate(&ys[0], <uint64_t>len(arr), b, k)
+    er = inform_entropy_rate(&ys[0], 1, <uint64_t>len(arr), b, k)
 
     if isnan(er):
         raise ValueError("invalid entropy rate computed (NaN)")
@@ -281,7 +284,7 @@ def entropyrate2d(arr, uint64_t k, uint64_t b):
         b = max(2,numpy.amax(arr)+1)
 
     cdef uint64_t [:] ys = arr.ravel()
-    er = inform_entropy_rate_ensemble(&ys[0], <uint64_t>shape[0], <uint64_t>shape[1], b, k)
+    er = inform_entropy_rate(&ys[0], <uint64_t>shape[0], <uint64_t>shape[1], b, k)
 
     if isnan(er):
         raise ValueError("invalid entropy rate computed (NaN)")

--- a/pyinform/pyinform.pyx
+++ b/pyinform/pyinform.pyx
@@ -137,12 +137,6 @@ cdef class Dist:
 cdef extern from "inform/active_info.h":
     double inform_active_info(const uint64_t* series, size_t n, size_t m, uint64_t base, uint64_t k)
 
-cdef extern from "inform/entropy_rate.h":
-    double inform_entropy_rate(const uint64_t* series, size_t n, size_t m, uint64_t base, uint64_t k)
-
-cdef extern from "inform/transfer_entropy.h":
-    double inform_transfer_entropy(const uint64_t* seriesy, const uint64_t* seriesx, size_t n, size_t m, uint64_t base, uint64_t k)
-
 def activeinfo1d(arr, uint64_t k, uint64_t b):
     from math import isnan
 
@@ -194,6 +188,9 @@ def activeinfo(xs, uint64_t k, uint64_t b = 0):
         return activeinfo2d(array, k, b)
     else:
         raise ValueError("arrays of dimension greater than 2 are not yet supported")
+
+cdef extern from "inform/transfer_entropy.h":
+    double inform_transfer_entropy(const uint64_t* seriesy, const uint64_t* seriesx, size_t n, size_t m, uint64_t base, uint64_t k)
 
 def transferentropy1d(ys, xs, uint64_t k, uint64_t b):
     from math import isnan
@@ -249,6 +246,9 @@ def transferentropy(ys, xs, uint64_t k, uint64_t b = 0):
         return transferentropy2d(ysarr, xsarr, k, b)
     else:
         raise ValueError("arrays of dimension greater than 2 are not yet supported")
+
+cdef extern from "inform/entropy_rate.h":
+    double inform_entropy_rate(const uint64_t* series, size_t n, size_t m, uint64_t base, uint64_t k)
 
 def entropyrate1d(arr, uint64_t k, uint64_t b):
     from math import isnan

--- a/pyinform/pyinform.pyx
+++ b/pyinform/pyinform.pyx
@@ -31,11 +31,11 @@ cdef class Dist:
     def __len__(self):
         return inform_dist_size(self._c_dist)
 
-cdef extern from "inform/time_series.h":
-    double inform_active_info(const uint64_t* series, size_t n, uint64_t base, uint64_t k)
-    double inform_active_info_ensemble(const uint64_t* series, size_t n, size_t m, uint64_t base, uint64_t k)
-    double inform_transfer_entropy(const uint64_t* seriesy, const uint64_t* seriesx, size_t n, uint64_t base, uint64_t k)
-    double inform_transfer_entropy_ensemble(const uint64_t* seriesy, const uint64_t* seriesx, size_t n, size_t m, uint64_t base, uint64_t k)
+cdef extern from "inform/active_info.h":
+    double inform_active_info(const uint64_t* series, size_t n, size_t m, uint64_t base, uint64_t k)
+
+cdef extern from "inform/transfer_entropy.h":
+    double inform_transfer_entropy(const uint64_t* seriesy, const uint64_t* seriesx, size_t n, size_t m, uint64_t base, uint64_t k)
 
 def activeinfo1d(arr, uint64_t k, uint64_t b):
     from math import isnan
@@ -50,7 +50,7 @@ def activeinfo1d(arr, uint64_t k, uint64_t b):
         b = max(2,max(arr)+1)
 
     cdef uint64_t [:] ys = arr
-    ai = inform_active_info(&ys[0], <uint64_t>len(arr), b, k)
+    ai = inform_active_info(&ys[0], 1, <uint64_t>len(arr), b, k)
 
     if isnan(ai):
         raise ValueError("invalid active information computed (NaN)")
@@ -71,7 +71,7 @@ def activeinfo2d(arr, uint64_t k, uint64_t b):
         b = max(2,numpy.amax(arr)+1)
 
     cdef uint64_t [:] ys = arr.ravel()
-    ai = inform_active_info_ensemble(&ys[0], <uint64_t>shape[0], <uint64_t>shape[1], b, k)
+    ai = inform_active_info(&ys[0], <uint64_t>shape[0], <uint64_t>shape[1], b, k)
 
     if isnan(ai):
         raise ValueError("invalid active information computed (NaN)")
@@ -103,7 +103,7 @@ def transferentropy1d(ys, xs, uint64_t k, uint64_t b):
 
     cdef uint64_t [:] ysarr = ys
     cdef uint64_t [:] xsarr = xs
-    te = inform_transfer_entropy(&ysarr[0], &xsarr[0], <uint64_t>len(ys), b, k)
+    te = inform_transfer_entropy(&ysarr[0], &xsarr[0], 1, <uint64_t>len(ys), b, k)
 
     if isnan(te):
         raise ValueError("invalid transfer entropy computed (NaN)")
@@ -125,7 +125,7 @@ def transferentropy2d(ys, xs, uint64_t k, uint64_t b):
 
     cdef uint64_t [:] ysarr = ys.ravel()
     cdef uint64_t [:] xsarr = xs.ravel()
-    te = inform_transfer_entropy_ensemble(&ysarr[0], &xsarr[0], <uint64_t>shape[0], <uint64_t>shape[1], b, k)
+    te = inform_transfer_entropy(&ysarr[0], &xsarr[0], <uint64_t>shape[0], <uint64_t>shape[1], b, k)
 
     if isnan(te):
         raise ValueError("invalid transfer entropy computed (NaN)")

--- a/test/test_transferentropy.py
+++ b/test/test_transferentropy.py
@@ -57,7 +57,8 @@ class TestTransferEntropy(unittest.TestCase):
         with self.assertRaises(ValueError):
             transferentropy(yseries, xseries, 2, 2)
 
-        transferentropy(xseries, yseries, 2, 2)
+        with self.assertRaises(ValueError):
+            transferentropy(xseries, yseries, 2, 2)
 
     def testSingleSeriesBase2(self):
         self.assertAlmostEqual(0.000000, transferentropy([1,1,1,0,0], [1,1,1,0,0], 2, 2), places=6)


### PR DESCRIPTION
The newest version of Inform removes the *_ensemble function names. inform_active_info, inform_entropy_rate and inform_transfer_entropy now require two size arguments, the first is the number of initial conditions and the second is the number of time steps.

This request propagates those API changes.