### PR TITLE
Add OS X support

### DIFF
--- a/pyinform/__init__.py
+++ b/pyinform/__init__.py
@@ -32,10 +32,17 @@ def get_libpath():
         raise ImportError("cannot find libinform")
 
     if system() == 'Linux':
-        return "{}/lib/libinform.so.{}.{}.{}".format(libdir,major,minor,revision)
+        platform = "linux-x86_64"
+        library = "libinform.so.{}.{}.{}".format(major,minor,revision)
+    elif system() == 'Darwin':
+        platform = "macosx-x86_64"
+        library = "libinform.{}.{}.{}.dylib".format(major,minor,revision)
     elif system() == 'Windows':
-        return "{}/lib/inform.dll".format(libdir)
+        platform = "win-amd64"
+        library = "inform.dll"
     else:
         raise RuntimeError("unsupported platform - \"{}\"".format(system()))
+
+    return os.path.join(libdir, "lib", platform, library)
 
 _inform = CDLL(get_libpath())

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,11 @@ with open('README.rst') as f:
 with open('LICENSE') as f:
     license = f.read()
 
-inform_version = "0.0.4"
+inform_version = "0.0.5"
 inform_files = [
-    "inform-{}/lib/libinform.so.{}".format(inform_version, inform_version),
-    "inform-{}/lib/inform.dll".format(inform_version)
+    "inform-{}/lib/linux-x86_64/libinform.so.{}".format(inform_version, inform_version),
+    "inform-{}/lib/macosx-x86_64/libinform.{}.dylib".format(inform_version, inform_version)
+    "inform-{}/lib/win_amd64/inform.dll".format(inform_version)
 ]
 
 setup(
@@ -29,5 +30,5 @@ setup(
     packages=['pyinform', 'pyinform.utils'],
     package_data = { 'pyinform' : inform_files },
     test_suite = "test",
-    platforms = ["Windows", "Linux"],
+    platforms = ["Windows", "OS X", "Linux"],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ with open('LICENSE') as f:
 inform_version = "0.0.5"
 inform_files = [
     "inform-{}/lib/linux-x86_64/libinform.so.{}".format(inform_version, inform_version),
-    "inform-{}/lib/macosx-x86_64/libinform.{}.dylib".format(inform_version, inform_version)
-    "inform-{}/lib/win_amd64/inform.dll".format(inform_version)
+    "inform-{}/lib/macosx-x86_64/libinform.{}.dylib".format(inform_version, inform_version),
+    "inform-{}/lib/win_amd64/inform.dll".format(inform_version),
 ]
 
 setup(


### PR DESCRIPTION
Supporting OS X at runtime was a snap. We simply added a branch in `get_libdir` to recognize the OS X platform and specify the path the the OS X inform binary. The path is predictable as the **pyinform/inform-0.0.5** directory should have the same structure as the contents of [inform-0.0.5_mixed.zip](https://github.com/elife-asu/inform/releases). We also updated the paths for the Linux and Windows binaries as they changed with the v0.0.5 release.

Instilling the binaries is pretty straightforward as well. We simply added the path of each to the `inform_files` variable in **setup.py**. We also added OS X to the list of supported platforms.

This merge will close #8 .