### PR TITLE
Implement Relative Entropy

### DIFF
--- a/pyinform/relativeentropy.py
+++ b/pyinform/relativeentropy.py
@@ -1,0 +1,46 @@
+# Copyright 2016 ELIFE. All rights reserved.
+# Use of this source code is governed by a MIT
+# license that can be found in the LICENSE file.
+import numpy as np
+
+from ctypes import byref, c_char_p, c_int, c_ulong, c_double, POINTER
+from pyinform import _inform
+from pyinform.error import ErrorCode, error_guard
+
+def relative_entropy(xs, ys, b=0, base=2.0, local=False):
+    """
+    Compute the relative entropy between two timeseries treating each as
+    observations from a distribution.
+    """
+    us = np.ascontiguousarray(xs, dtype=np.int32)
+    vs = np.ascontiguousarray(ys, dtype=np.int32)
+    if us.shape != vs.shape:
+        raise ValueError("timeseries lengths do not match")
+
+    if b == 0:
+        b = max(2, np.amax(us)+1, np.amax(vs)+1)
+
+    xdata = us.ctypes.data_as(POINTER(c_int))
+    ydata = vs.ctypes.data_as(POINTER(c_int))
+    n = us.size
+
+    e = ErrorCode(0)
+
+    if local is True:
+        re = np.empty(b, dtype=np.float64)
+        out = re.ctypes.data_as(POINTER(c_double))
+        _local_relative_entropy(xdata, ydata, c_ulong(n), c_int(b), c_double(base), out, byref(e))
+    else:
+        re = _relative_entropy(xdata, ydata, c_ulong(n), c_int(b), c_double(base), byref(e))
+
+    error_guard(e)
+
+    return re
+
+_relative_entropy = _inform.inform_relative_entropy
+_relative_entropy.argtypes = [POINTER(c_int), POINTER(c_int), c_ulong, c_int, c_double, POINTER(c_int)]
+_relative_entropy.restype = c_double
+
+_local_relative_entropy = _inform.inform_local_relative_entropy
+_local_relative_entropy.argtypes = [POINTER(c_int), POINTER(c_int), c_ulong, c_int, c_double, POINTER(c_double), POINTER(c_int)]
+_local_relative_entropy.restype = POINTER(c_double)

--- a/test/test_relativeentropy.py
+++ b/test/test_relativeentropy.py
@@ -1,0 +1,242 @@
+# Copyright 2016 ELIFE. All rights reserved.
+# Use of this source code is governed by a MIT
+# license that can be found in the LICENSE file.
+import unittest
+from pyinform.error import InformError
+from pyinform.relativeentropy import *
+from math import isnan, isinf
+
+class TestRelativeEntropy(unittest.TestCase):
+    def assertQuasiEqual(self, x, y, places=7):
+        if isnan(x) and isnan(y):
+            return
+        elif isinf(x) and isinf(y):
+            return
+        elif isnan(x) or isnan(y):
+            self.fail("unequal NaN values")
+        elif isinf(x) or isinf(y):
+            self.fail("unequal infinite values")
+        else:
+            self.assertAlmostEqual(x, y, places=places)
+
+    def test_relative_entropy_empty(self):
+        with self.assertRaises(ValueError):
+            relative_entropy([], [])
+
+        with self.assertRaises(ValueError):
+            relative_entropy([1,2,3], [])
+
+        with self.assertRaises(ValueError):
+            relative_entropy([], [1,2,3])
+
+    def test_relative_entropy_dimensions(self):
+        with self.assertRaises(ValueError):
+            relative_entropy([[1]], [1])
+
+        with self.assertRaises(ValueError):
+            relative_entropy([1], [[1]])
+
+    def test_relative_entropy_size(self):
+        with self.assertRaises(ValueError):
+            relative_entropy([1,2,3], [1,2])
+
+        with self.assertRaises(ValueError):
+            relative_entropy([1,2], [1,2,3])
+
+    def test_relative_entropy_invalid_base(self):
+        with self.assertRaises(InformError):
+            relative_entropy([0,0,1], [0,0,1], b=1)
+
+    def test_relative_entropy_negative_states(self):
+        with self.assertRaises(InformError):
+            relative_entropy([-1,0,0], [0,0,1])
+
+        with self.assertRaises(InformError):
+            relative_entropy([1,0,0], [0,0,-1])
+
+    def test_relative_entropy_bad_states(self):
+        with self.assertRaises(InformError):
+            relative_entropy([0,2,0], [0,0,1], b=2)
+
+    def test_relative_entropy(self):
+        self.assertAlmostEqual(0.038331,
+                relative_entropy([0,0,1,1,1,1,0,0,0], [1,0,0,1,0,0,1,0,0]),
+                places=6)
+
+        self.assertAlmostEqual(0.037010,
+                relative_entropy([1,0,0,1,0,0,1,0,0], [0,0,1,1,1,1,0,0,0]),
+                places=6)
+
+        self.assertAlmostEqual(0.000000,
+                relative_entropy([0,0,0,0,1,1,1,1], [1,1,1,1,0,0,0,0]),
+                places=6)
+
+        self.assertAlmostEqual(0.035770,
+                relative_entropy([0,0,1,1,1,1,0,0,0], [1,1,0,0,0,0,1,1,1]),
+                places=6)
+
+        self.assertAlmostEqual(0.037010,
+                relative_entropy([1,1,0,1,0,1,1,1,0], [1,1,0,0,0,1,0,1,1]),
+                places=6)
+
+        self.assertAlmostEqual(1.584963,
+                relative_entropy([0,0,0,0,0,0,0,0,0], [1,1,1,0,0,0,1,1,1]),
+                places=6)
+
+        self.assertAlmostEqual(0.038331,
+                relative_entropy([1,1,1,1,0,0,0,0,1], [1,1,1,0,0,0,1,1,1]),
+                places=6)
+
+        self.assertAlmostEqual(0.038331,
+                relative_entropy([1,1,0,0,1,1,0,0,1], [1,1,1,0,0,0,1,1,1]),
+                places=6)
+
+        self.assertTrue(isnan(relative_entropy([0,1,0,1,0,1,0,1], [0,2,0,2,0,2,0,2])))
+
+        self.assertAlmostEqual(0.584963,
+                relative_entropy([0,0,0,0,0,0,1,1,1,1,1,1], [0,0,0,0,1,1,1,1,2,2,2,2]),
+                places=6)
+
+        self.assertTrue(isnan(relative_entropy([0,0,1,1,2,1,1,0,0], [0,0,0,1,1,1,0,0,0])))
+
+        self.assertAlmostEqual(0.000000,
+                relative_entropy([0,1,0,0,1,0,0,1,0], [1,0,0,1,0,0,1,0,0]),
+                places=6)
+
+        self.assertAlmostEqual(0.679964,
+                relative_entropy([1,0,0,1,0,0,1,0], [2,0,1,2,0,1,2,0]),
+                places=6)
+
+    def test_relative_entropy_2D(self):
+        xs = np.random.randint(0,5,20)
+        ys = np.random.randint(0,5,20)
+        expect = relative_entropy(xs, ys, b=5)
+
+        us = np.copy(np.reshape(xs, (4,5)))
+        vs = np.copy(np.reshape(ys, (4,5)))
+        got = relative_entropy(us, vs, b=5)
+
+        self.assertQuasiEqual(expect, got)
+
+class TestLocalRelativeEntropy(unittest.TestCase):
+    def assertQuasiEqual(self, expect, got, places=7):
+        self.assertEqual(len(expect), len(got))
+        for i in range(len(expect)):
+            if isnan(expect[i]) and isnan(got[i]):
+                continue
+            elif isinf(expect[i]) and isinf(got[i]):
+                continue
+            elif isnan(expect[i]) or isnan(got[i]):
+                self.fail("unequal NaN values")
+            elif isinf(expect[i]) or isinf(got[i]):
+                self.fail("unequal infinite values")
+            else:
+                self.assertAlmostEqual(expect[i], got[i], places=places)
+
+    def test_relative_entropy_empty(self):
+        with self.assertRaises(ValueError):
+            relative_entropy([], [], local=True)
+
+        with self.assertRaises(ValueError):
+            relative_entropy([1,2,3], [], local=True)
+
+        with self.assertRaises(ValueError):
+            relative_entropy([], [1,2,3], local=True)
+
+    def test_relative_entropy_dimensions(self):
+        with self.assertRaises(ValueError):
+            relative_entropy([[1]], [1], local=True)
+
+        with self.assertRaises(ValueError):
+            relative_entropy([1], [[1]], local=True)
+
+    def test_relative_entropy_size(self):
+        with self.assertRaises(ValueError):
+            relative_entropy([1,2,3], [1,2], local=True)
+
+        with self.assertRaises(ValueError):
+            relative_entropy([1,2], [1,2,3], local=True)
+
+    def test_relative_entropy_invalid_base(self):
+        with self.assertRaises(InformError):
+            relative_entropy([0,0,1], [0,0,1], b=1, local=True)
+
+    def test_relative_entropy_negative_states(self):
+        with self.assertRaises(InformError):
+            relative_entropy([-1,0,0], [0,0,1], local=True)
+
+        with self.assertRaises(InformError):
+            relative_entropy([1,0,0], [0,0,-1], local=True)
+
+    def test_relative_entropy_bad_states(self):
+        with self.assertRaises(InformError):
+            relative_entropy([0,2,0], [0,0,1], b=2, local=True)
+
+    def test_relative_entropy(self):
+        self.assertQuasiEqual([-0.263034, 0.415037],
+                relative_entropy([0,0,1,1,1,1,0,0,0], [1,0,0,1,0,0,1,0,0], local=True),
+                places=6)
+
+        self.assertQuasiEqual([0.263034, -0.415037],
+                relative_entropy([1,0,0,1,0,0,1,0,0], [0,0,1,1,1,1,0,0,0], local=True),
+                places=6)
+
+        self.assertQuasiEqual([0.000000, 0.000000],
+                relative_entropy([0,0,0,0,1,1,1,1], [1,1,1,1,0,0,0,0], local=True),
+                places=6)
+
+        self.assertQuasiEqual([0.321928, -0.321928],
+                relative_entropy([0,0,1,1,1,1,0,0,0], [1,1,0,0,0,0,1,1,1], local=True),
+                places=6)
+
+        self.assertQuasiEqual([-0.415037, 0.263034],
+                relative_entropy([1,1,0,1,0,1,1,1,0], [1,1,0,0,0,1,0,1,1], local=True),
+                places=6)
+
+        self.assertQuasiEqual([1.584963, -float('Inf')],
+                relative_entropy([0,0,0,0,0,0,0,0,0], [1,1,1,0,0,0,1,1,1], local=True),
+                places=6)
+
+        self.assertQuasiEqual([0.415037, -0.263034],
+                relative_entropy([1,1,1,1,0,0,0,0,1], [1,1,1,0,0,0,1,1,1], local=True),
+                places=6)
+
+        self.assertQuasiEqual([0.415037, -0.263034],
+                relative_entropy([1,1,0,0,1,1,0,0,1], [1,1,1,0,0,0,1,1,1], local=True),
+                places=6)
+
+        self.assertQuasiEqual([0.000000, float('Inf'), -float('Inf')],
+                relative_entropy([0,1,0,1,0,1,0,1], [0,2,0,2,0,2,0,2], local=True),
+                places=6)
+
+        self.assertQuasiEqual([0.584963, 0.584963, -float('Inf')],
+                relative_entropy([0,0,0,0,0,0,1,1,1,1,1,1], [0,0,0,0,1,1,1,1,2,2,2,2], local=True),
+                places=6)
+
+        self.assertQuasiEqual([-0.584963, 0.415037, float('Inf')],
+                relative_entropy([0,0,1,1,2,1,1,0,0], [0,0,0,1,1,1,0,0,0], local=True),
+                places=6)
+
+        self.assertQuasiEqual([0.000000, 0.000000],
+                relative_entropy([0,1,0,0,1,0,0,1,0], [1,0,0,1,0,0,1,0,0], local=True),
+                places=6)
+
+        self.assertQuasiEqual([0.736966, 0.584963, -float('Inf')],
+                relative_entropy([1,0,0,1,0,0,1,0], [2,0,1,2,0,1,2,0], local=True),
+                places=6)
+
+    def test_relative_entropy_2D(self):
+        xs = np.random.randint(0,5,20)
+        ys = np.random.randint(0,5,20)
+        expect = relative_entropy(xs, ys, b=5, local=True)
+        self.assertEqual((5,), expect.shape)
+
+        us = np.copy(np.reshape(xs, (4,5)))
+        vs = np.copy(np.reshape(ys, (4,5)))
+        got = relative_entropy(us, vs, b=5, local=True)
+        self.assertTrue((5,), got.shape)
+
+        self.assertQuasiEqual(expect, np.reshape(got,expect.shape))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This merge brings in an implementation of relative entropy on time series data. Each time series is assumed to represent a sequence of observations from some distribution, and the `relative_entropy` function computes the relative entropy using the first argument to construct the *posterior* distribution and the second argument to construct the *prior*.

This merge will close #10 .