### PR TITLE
Disable travis-ci build on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 os:
     - linux
-    - osx
+    # - osx
 
 python:
   - "2.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+version: 0.0.5.{build}
+
 environment:
   matrix:
     - PYTHON: "C:\\Python27-x64"


### PR DESCRIPTION
Apparently Travis-CI does not support python on OS X. We'll enable OS X support when Travis-CI does.