### PR TITLE
Add implicit imports

### DIFF
--- a/pyinform/__init__.py
+++ b/pyinform/__init__.py
@@ -46,3 +46,14 @@ def get_libpath():
     return os.path.join(libdir, "lib", platform, library)
 
 _inform = CDLL(get_libpath())
+
+from .activeinfo import active_info
+from .blockentropy import block_entropy
+from .dist import Dist
+from .entropyrate import entropy_rate
+from .error import InformError
+from .mutualinfo import mutual_info
+from .transferentropy import transfer_entropy
+
+from . import shannon
+from . import utils

--- a/pyinform/__init__.py
+++ b/pyinform/__init__.py
@@ -49,10 +49,12 @@ _inform = CDLL(get_libpath())
 
 from .activeinfo import active_info
 from .blockentropy import block_entropy
+from .conditionalentropy import conditional_entropy
 from .dist import Dist
 from .entropyrate import entropy_rate
 from .error import InformError
 from .mutualinfo import mutual_info
+from .relativeentropy import relative_entropy
 from .transferentropy import transfer_entropy
 
 from . import shannon


### PR DESCRIPTION
Rather than having to have import the various time series functions from their respective modules, we can now `from pyinform import *` and get all of them!